### PR TITLE
Seekbar Bug Fixes and Optimizations

### DIFF
--- a/BasicPlayback/BasicPlayback/ViewController.swift
+++ b/BasicPlayback/BasicPlayback/ViewController.swift
@@ -159,6 +159,7 @@ class ViewController: UIViewController {
             position = playerPosition
             updateSeekSlider(position: position, duration: duration)
         }
+        guard position.seconds.isNormal else { return }
         currentPositionLabel.text = timeDisplayFormatter.string(from: position.seconds)
     }
 


### PR DESCRIPTION
### Issue #, if available:

None.

### Description of changes:

Fixes a crash if the user tapped the seekbar before the player has determined the video duration.

-------------

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
