### PR TITLE
Check player error state before resuming playback on foreground trans…

### DIFF
--- a/BasicPlayback/BasicPlayback/ViewController.swift
+++ b/BasicPlayback/BasicPlayback/ViewController.swift
@@ -96,7 +96,7 @@ class ViewController: UIViewController {
     }
 
     @objc private func applicationDidBecomeActive(notification: Notification) {
-        if didPauseOnBackground {
+        if didPauseOnBackground && player?.error == nil {
             startPlayback()
             didPauseOnBackground = false
         }

--- a/CustomUI/CustomUI/Controllers/MainViewController.swift
+++ b/CustomUI/CustomUI/Controllers/MainViewController.swift
@@ -327,7 +327,7 @@ extension MainViewController {
     @objc func applicationDidBecomeActive() {
         print("ℹ️ Application did become active")
         if #available(iOS 12.0, *) { isDarkMode = traitCollection.userInterfaceStyle == .dark }
-        if player?.state == .idle {
+        if player?.state == .idle && player?.error == nil {
             player?.play()
         }
     }
@@ -336,7 +336,7 @@ extension MainViewController {
         print("ℹ️ Application will enter foreground")
         playerView.player = player
         startPeriodicTimer()
-        if player?.state == .idle {
+        if player?.state == .idle && player?.error == nil {
             player?.play()
         }
     }


### PR DESCRIPTION
*Issue #, if available:*
None

*Description of changes:*
Check the error state before automatically resuming playback on foreground transitions.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
