### PR TITLE
Remove unused metadata delegate method

### DIFF
--- a/BasicPlayback/BasicPlayback/ViewController.swift
+++ b/BasicPlayback/BasicPlayback/ViewController.swift
@@ -395,16 +395,6 @@ extension ViewController: IVSPlayer.Delegate {
         }
     }
 
-    func player(_ player: IVSPlayer, didOutputMetadataWithType type: String, content: Data) {
-        if type == "text/plain" {
-            guard let textData = String(data: content, encoding: .utf8) else {
-                print("Unable to parse metadata as string")
-                return
-            }
-            print("Received Timed Metadata: \(textData)")
-        }
-    }
-
     func playerWillRebuffer(_ player: IVSPlayer) {
         print("Player will rebuffer and resume playback")
     }


### PR DESCRIPTION
*Description of changes:*
Removes a metadata callback method from the BasicPlayback example. This callback is never invoked, and its apparent intended functionality is handled by the `IVSTextMetadataCue` case above it.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
