### PR TITLE
Update AmazonIVSPlayer Pod to 1.3.3

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,7 +2,7 @@ GEM
   remote: https://rubygems.org/
   specs:
     CFPropertyList (3.0.3)
-    activesupport (5.2.5)
+    activesupport (5.2.6)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 0.7, < 2)
       minitest (~> 5.1)
@@ -56,7 +56,7 @@ GEM
     escape (0.0.4)
     ethon (0.14.0)
       ffi (>= 1.15.0)
-    ffi (1.15.0)
+    ffi (1.15.1)
     fourflusher (2.3.1)
     fuzzy_match (2.0.4)
     gh_inspector (1.1.3)

--- a/Podfile
+++ b/Podfile
@@ -4,7 +4,7 @@ workspace 'AmazonIVSPlayerSamples'
 
 # All of the following projects consume the AmazonIVSPlayer framework as clients
 abstract_target 'IVSClients' do
-    pod 'AmazonIVSPlayer', '~> 1.3.0'
+    pod 'AmazonIVSPlayer', '~> 1.3.3'
 
     target 'BasicPlayback' do
         project 'BasicPlayback/BasicPlayback.xcodeproj'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,16 +1,16 @@
 PODS:
-  - AmazonIVSPlayer (1.3.0)
+  - AmazonIVSPlayer (1.3.3)
 
 DEPENDENCIES:
-  - AmazonIVSPlayer (~> 1.3.0)
+  - AmazonIVSPlayer (~> 1.3.3)
 
 SPEC REPOS:
   trunk:
     - AmazonIVSPlayer
 
 SPEC CHECKSUMS:
-  AmazonIVSPlayer: ae0ed2a02fa8707225170b6c784f446e93a7afd6
+  AmazonIVSPlayer: 43482c52521fbe36c6fdee48eb336fbcda87be7a
 
-PODFILE CHECKSUM: 62d09f66d956ebfc1769f1c0ed978b48e15bd627
+PODFILE CHECKSUM: 2b2d74ef8b304178224279dc30223db9b9e6d22c
 
 COCOAPODS: 1.10.1


### PR DESCRIPTION
*Description of changes:*
Updates the AmazonIVSPlayer SDK dependency to 1.3.3.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
