### PR TITLE
Update AmazonIVSPlayer Pod to 1.4.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,3 @@
 source 'https://rubygems.org'
 
 gem 'cocoapods'
-
-# Unlisted dependency of Xcodeproj, a CocoaPods component.
-# Fixed but unreleased: https://github.com/CocoaPods/CocoaPods/issues/10388#issuecomment-815114601
-gem 'rexml', '~> 3.2.4'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -14,10 +14,10 @@ GEM
       json (>= 1.5.1)
     atomos (0.1.3)
     claide (1.0.3)
-    cocoapods (1.10.1)
+    cocoapods (1.10.2)
       addressable (~> 2.6)
       claide (>= 1.0.2, < 2.0)
-      cocoapods-core (= 1.10.1)
+      cocoapods-core (= 1.10.2)
       cocoapods-deintegrate (>= 1.0.3, < 2.0)
       cocoapods-downloader (>= 1.4.0, < 2.0)
       cocoapods-plugins (>= 1.0.0, < 2.0)
@@ -32,7 +32,7 @@ GEM
       nap (~> 1.0)
       ruby-macho (~> 1.4)
       xcodeproj (>= 1.19.0, < 2.0)
-    cocoapods-core (1.10.1)
+    cocoapods-core (1.10.2)
       activesupport (> 5.0, < 6)
       addressable (~> 2.6)
       algoliasearch (~> 1.0)
@@ -52,11 +52,11 @@ GEM
       netrc (~> 0.11)
     cocoapods-try (1.2.0)
     colored2 (3.1.2)
-    concurrent-ruby (1.1.8)
+    concurrent-ruby (1.1.9)
     escape (0.0.4)
     ethon (0.14.0)
       ffi (>= 1.15.0)
-    ffi (1.15.1)
+    ffi (1.15.3)
     fourflusher (2.3.1)
     fuzzy_match (2.0.4)
     gh_inspector (1.1.3)
@@ -77,19 +77,19 @@ GEM
       ethon (>= 0.9.0)
     tzinfo (1.2.9)
       thread_safe (~> 0.1)
-    xcodeproj (1.19.0)
+    xcodeproj (1.21.0)
       CFPropertyList (>= 2.3.3, < 4.0)
       atomos (~> 0.1.3)
       claide (>= 1.0.2, < 2.0)
       colored2 (~> 3.1)
       nanaimo (~> 0.3.0)
+      rexml (~> 3.2.4)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
   cocoapods
-  rexml (~> 3.2.4)
 
 BUNDLED WITH
    1.17.2

--- a/Podfile
+++ b/Podfile
@@ -4,7 +4,7 @@ workspace 'AmazonIVSPlayerSamples'
 
 # All of the following projects consume the AmazonIVSPlayer framework as clients
 abstract_target 'IVSClients' do
-    pod 'AmazonIVSPlayer', '~> 1.3.3'
+    pod 'AmazonIVSPlayer', '~> 1.4.0'
 
     target 'BasicPlayback' do
         project 'BasicPlayback/BasicPlayback.xcodeproj'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,16 +1,16 @@
 PODS:
-  - AmazonIVSPlayer (1.3.3)
+  - AmazonIVSPlayer (1.4.0)
 
 DEPENDENCIES:
-  - AmazonIVSPlayer (~> 1.3.3)
+  - AmazonIVSPlayer (~> 1.4.0)
 
 SPEC REPOS:
   trunk:
     - AmazonIVSPlayer
 
 SPEC CHECKSUMS:
-  AmazonIVSPlayer: 43482c52521fbe36c6fdee48eb336fbcda87be7a
+  AmazonIVSPlayer: e59061ba27a86c3dbfb9db0cacfc49d6abcaeb36
 
-PODFILE CHECKSUM: 2b2d74ef8b304178224279dc30223db9b9e6d22c
+PODFILE CHECKSUM: df51f27b0ff5fb31f218c73c5760e147d5d17d62
 
-COCOAPODS: 1.10.1
+COCOAPODS: 1.10.2


### PR DESCRIPTION
This updates the SDK dependency to the current version, 1.4.0. Gem dependencies have been updated as well.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
