### PR TITLE
Update AmazonIVSPlayer Pod to 1.5.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,8 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    CFPropertyList (3.0.3)
+    CFPropertyList (3.0.4)
+      rexml
     activesupport (6.1.4.1)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 1.6, < 2)
@@ -15,10 +16,10 @@ GEM
       json (>= 1.5.1)
     atomos (0.1.3)
     claide (1.0.3)
-    cocoapods (1.11.0)
+    cocoapods (1.11.2)
       addressable (~> 2.8)
       claide (>= 1.0.2, < 2.0)
-      cocoapods-core (= 1.11.0)
+      cocoapods-core (= 1.11.2)
       cocoapods-deintegrate (>= 1.0.3, < 2.0)
       cocoapods-downloader (>= 1.4.0, < 2.0)
       cocoapods-plugins (>= 1.0.0, < 2.0)
@@ -33,7 +34,7 @@ GEM
       nap (~> 1.0)
       ruby-macho (>= 1.0, < 3.0)
       xcodeproj (>= 1.21.0, < 2.0)
-    cocoapods-core (1.11.0)
+    cocoapods-core (1.11.2)
       activesupport (>= 5.0, < 7)
       addressable (~> 2.8)
       algoliasearch (~> 1.0)
@@ -93,4 +94,4 @@ DEPENDENCIES
   cocoapods
 
 BUNDLED WITH
-   1.17.2
+   2.2.28

--- a/Podfile
+++ b/Podfile
@@ -4,7 +4,7 @@ workspace 'AmazonIVSPlayerSamples'
 
 # All of the following projects consume the AmazonIVSPlayer framework as clients
 abstract_target 'IVSClients' do
-    pod 'AmazonIVSPlayer', '~> 1.4.1'
+    pod 'AmazonIVSPlayer', '~> 1.5.0'
 
     target 'BasicPlayback' do
         project 'BasicPlayback/BasicPlayback.xcodeproj'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,16 +1,16 @@
 PODS:
-  - AmazonIVSPlayer (1.4.1)
+  - AmazonIVSPlayer (1.5.0)
 
 DEPENDENCIES:
-  - AmazonIVSPlayer (~> 1.4.1)
+  - AmazonIVSPlayer (~> 1.5.0)
 
 SPEC REPOS:
   trunk:
     - AmazonIVSPlayer
 
 SPEC CHECKSUMS:
-  AmazonIVSPlayer: 373604429cac7e1bacdac93f7efdddae8d0c8e2f
+  AmazonIVSPlayer: 7ab35f4145c3211646fae88fd15604cb89404b62
 
-PODFILE CHECKSUM: 9282e57bb4fb7db18962bf83f7d113ad4095cf30
+PODFILE CHECKSUM: a8711799441dfe67a676b2c59bc2034a91b873b5
 
-COCOAPODS: 1.11.0
+COCOAPODS: 1.11.2


### PR DESCRIPTION
This updates the SDK dependency to the current version, 1.5.0. Gem dependencies have been updated as well.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.