### PR TITLE
Fix notification mismatch in observer removal

### DIFF
--- a/BasicPlayback/BasicPlayback/ViewController.swift
+++ b/BasicPlayback/BasicPlayback/ViewController.swift
@@ -109,7 +109,7 @@ class ViewController: UIViewController {
 
     private func removeApplicationLifecycleObservers() {
         NotificationCenter.default.removeObserver(self, name: UIApplication.didEnterBackgroundNotification, object: nil)
-        NotificationCenter.default.removeObserver(self, name: UIApplication.willEnterForegroundNotification, object: nil)
+        NotificationCenter.default.removeObserver(self, name: UIApplication.didBecomeActiveNotification, object: nil)
     }
 
     // MARK: State display


### PR DESCRIPTION
*Description of changes:*
In BasicPlayback, a callback is registered for `UIApplication.didBecomeActiveNotification`, but removed for `UIApplication.willEnterForegroundNotification` on cleanup.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
