### PR TITLE
Update AmazonIVSPlayer pod to 1.6.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 GEM
   remote: https://rubygems.org/
   specs:
-    CFPropertyList (3.0.4)
+    CFPropertyList (3.0.5)
       rexml
     activesupport (6.1.4.1)
       concurrent-ruby (~> 1.0, >= 1.0.2)
@@ -56,16 +56,16 @@ GEM
     colored2 (3.1.2)
     concurrent-ruby (1.1.9)
     escape (0.0.4)
-    ethon (0.14.0)
+    ethon (0.15.0)
       ffi (>= 1.15.0)
     ffi (1.15.4)
     fourflusher (2.3.1)
     fuzzy_match (2.0.4)
     gh_inspector (1.1.3)
     httpclient (2.8.3)
-    i18n (1.8.10)
+    i18n (1.8.11)
       concurrent-ruby (~> 1.0)
-    json (2.5.1)
+    json (2.6.1)
     minitest (5.14.4)
     molinillo (0.8.0)
     nanaimo (0.3.0)
@@ -85,7 +85,7 @@ GEM
       colored2 (~> 3.1)
       nanaimo (~> 0.3.0)
       rexml (~> 3.2.4)
-    zeitwerk (2.4.2)
+    zeitwerk (2.5.1)
 
 PLATFORMS
   ruby

--- a/Podfile
+++ b/Podfile
@@ -4,7 +4,7 @@ workspace 'AmazonIVSPlayerSamples'
 
 # All of the following projects consume the AmazonIVSPlayer framework as clients
 abstract_target 'IVSClients' do
-    pod 'AmazonIVSPlayer', '~> 1.5.0'
+    pod 'AmazonIVSPlayer', '~> 1.6.0'
 
     target 'BasicPlayback' do
         project 'BasicPlayback/BasicPlayback.xcodeproj'
@@ -16,13 +16,5 @@ abstract_target 'IVSClients' do
 
     target 'QuizDemo' do
         project 'QuizDemo/QuizDemo.xcodeproj'
-    end
-end
-
-# Allow building for arm64e architecture, which AmazonIVSPlayer supports.
-# See https://developer.apple.com/documentation/security/preparing_your_app_to_work_with_pointer_authentication
-post_install do |installer|
-    installer.pods_project.build_configurations.each do |configuration|
-        configuration.build_settings['ARCHS[sdk=iphoneos*]'] = ['$(ARCHS_STANDARD)','arm64e']
     end
 end

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,16 +1,16 @@
 PODS:
-  - AmazonIVSPlayer (1.5.0)
+  - AmazonIVSPlayer (1.6.0)
 
 DEPENDENCIES:
-  - AmazonIVSPlayer (~> 1.5.0)
+  - AmazonIVSPlayer (~> 1.6.0)
 
 SPEC REPOS:
   trunk:
     - AmazonIVSPlayer
 
 SPEC CHECKSUMS:
-  AmazonIVSPlayer: 7ab35f4145c3211646fae88fd15604cb89404b62
+  AmazonIVSPlayer: ffb432b2359faad4d6e91c5c4b9bbe726d42c5af
 
-PODFILE CHECKSUM: a8711799441dfe67a676b2c59bc2034a91b873b5
+PODFILE CHECKSUM: 5a121dbabe5d40f6e05e071f0a0bf27e61153fb9
 
 COCOAPODS: 1.11.2


### PR DESCRIPTION
This updates the SDK dependency to the current version, 1.6.0. Gem dependencies have been updated as well.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
