### PR TITLE
Update AmazonIVSPlayer Pod to 1.8.2

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -45,7 +45,7 @@ GEM
       public_suffix (~> 4.0)
       typhoeus (~> 1.0)
     cocoapods-deintegrate (1.0.5)
-    cocoapods-downloader (1.6.2)
+    cocoapods-downloader (1.6.3)
     cocoapods-plugins (1.0.0)
       nap
     cocoapods-search (1.0.1)
@@ -71,7 +71,7 @@ GEM
     nanaimo (0.3.0)
     nap (1.1.0)
     netrc (0.11.0)
-    public_suffix (4.0.6)
+    public_suffix (4.0.7)
     rexml (3.2.5)
     ruby-macho (2.5.1)
     typhoeus (1.4.0)

--- a/Podfile
+++ b/Podfile
@@ -4,7 +4,7 @@ workspace 'AmazonIVSPlayerSamples'
 
 # All of the following projects consume the AmazonIVSPlayer framework as clients
 abstract_target 'IVSClients' do
-    pod 'AmazonIVSPlayer', '~> 1.8.1'
+    pod 'AmazonIVSPlayer', '~> 1.8.2'
 
     target 'BasicPlayback' do
         project 'BasicPlayback/BasicPlayback.xcodeproj'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,16 +1,16 @@
 PODS:
-  - AmazonIVSPlayer (1.8.1)
+  - AmazonIVSPlayer (1.8.2)
 
 DEPENDENCIES:
-  - AmazonIVSPlayer (~> 1.8.1)
+  - AmazonIVSPlayer (~> 1.8.2)
 
 SPEC REPOS:
   trunk:
     - AmazonIVSPlayer
 
 SPEC CHECKSUMS:
-  AmazonIVSPlayer: f366e1f62463f653dc1dc4a9e54225230c3c19b9
+  AmazonIVSPlayer: 5fa9ee5782d3f8e85ddcebf189fa9d9de6ae27e2
 
-PODFILE CHECKSUM: 2806e519aa97db69eeecad9b2b6e50d9deea5660
+PODFILE CHECKSUM: 6793205f27ad5670fda494a367d6f92eafcd9430
 
 COCOAPODS: 1.11.3


### PR DESCRIPTION
This updates the SDK dependency to the current version, 1.8.2. Gem dependencies have been updated as well.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
