### PR TITLE
Update AmazonIVSPlayer to version 1.20.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,7 +3,7 @@ GEM
   specs:
     CFPropertyList (3.0.6)
       rexml
-    activesupport (7.0.4.3)
+    activesupport (7.0.6)
       concurrent-ruby (~> 1.0, >= 1.0.2)
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
@@ -62,10 +62,10 @@ GEM
     fuzzy_match (2.0.4)
     gh_inspector (1.1.3)
     httpclient (2.8.3)
-    i18n (1.13.0)
+    i18n (1.14.1)
       concurrent-ruby (~> 1.0)
     json (2.6.3)
-    minitest (5.18.0)
+    minitest (5.18.1)
     molinillo (0.8.0)
     nanaimo (0.3.0)
     nap (1.1.0)

--- a/Podfile
+++ b/Podfile
@@ -1,10 +1,10 @@
-platform :ios, '11.0'
+platform :ios, '12.0'
 
 workspace 'AmazonIVSPlayerSamples'
 
 # All of the following projects consume the AmazonIVSPlayer framework as clients
 abstract_target 'IVSClients' do
-    pod 'AmazonIVSPlayer', '1.19.0'
+    pod 'AmazonIVSPlayer', '1.20.0'
 
     target 'BasicPlayback' do
         project 'BasicPlayback/BasicPlayback.xcodeproj'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,16 +1,16 @@
 PODS:
-  - AmazonIVSPlayer (1.19.0)
+  - AmazonIVSPlayer (1.20.0)
 
 DEPENDENCIES:
-  - AmazonIVSPlayer (= 1.19.0)
+  - AmazonIVSPlayer (= 1.20.0)
 
 SPEC REPOS:
   trunk:
     - AmazonIVSPlayer
 
 SPEC CHECKSUMS:
-  AmazonIVSPlayer: b9498771b74cd05e93c67dd3844bb4e2c453f2aa
+  AmazonIVSPlayer: 2183a141f179d74251ba041eda22c75cd0f41fc7
 
-PODFILE CHECKSUM: 188e3074ca0bd1cf011d825acdc2b25afbba6eb8
+PODFILE CHECKSUM: 769e767a95396f0e0eed6d6eefb93a1a2fdf0b10
 
 COCOAPODS: 1.12.1


### PR DESCRIPTION
This updates the SDK dependency to the current version, 1.20.0. Gem dependencies have been updated as well.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.