### PR TITLE
Update AmazonIVSPlayer to version 1.26.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -5,7 +5,7 @@ GEM
       base64
       nkf
       rexml
-    activesupport (7.1.3)
+    activesupport (7.1.3.2)
       base64
       bigdecimal
       concurrent-ruby (~> 1.0, >= 1.0.2)
@@ -22,7 +22,7 @@ GEM
       json (>= 1.5.1)
     atomos (0.1.3)
     base64 (0.2.0)
-    bigdecimal (3.1.6)
+    bigdecimal (3.1.7)
     claide (1.1.0)
     cocoapods (1.15.2)
       addressable (~> 2.8)
@@ -64,8 +64,7 @@ GEM
     colored2 (3.1.2)
     concurrent-ruby (1.2.3)
     connection_pool (2.4.1)
-    drb (2.2.0)
-      ruby2_keywords
+    drb (2.2.1)
     escape (0.0.4)
     ethon (0.16.0)
       ffi (>= 1.15.0)
@@ -74,10 +73,10 @@ GEM
     fuzzy_match (2.0.4)
     gh_inspector (1.1.3)
     httpclient (2.8.3)
-    i18n (1.14.1)
+    i18n (1.14.4)
       concurrent-ruby (~> 1.0)
     json (2.7.1)
-    minitest (5.22.2)
+    minitest (5.22.3)
     molinillo (0.8.0)
     mutex_m (0.2.0)
     nanaimo (0.3.0)
@@ -87,7 +86,6 @@ GEM
     public_suffix (4.0.7)
     rexml (3.2.6)
     ruby-macho (2.5.1)
-    ruby2_keywords (0.0.5)
     typhoeus (1.4.1)
       ethon (>= 0.9.0)
     tzinfo (2.0.6)

--- a/Podfile
+++ b/Podfile
@@ -4,7 +4,7 @@ workspace 'AmazonIVSPlayerSamples'
 
 # All of the following projects consume the AmazonIVSPlayer framework as clients
 abstract_target 'IVSClients' do
-    pod 'AmazonIVSPlayer', '1.25.0'
+    pod 'AmazonIVSPlayer', '1.26.0'
 
     target 'BasicPlayback' do
         project 'BasicPlayback/BasicPlayback.xcodeproj'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,16 +1,16 @@
 PODS:
-  - AmazonIVSPlayer (1.25.0)
+  - AmazonIVSPlayer (1.26.0)
 
 DEPENDENCIES:
-  - AmazonIVSPlayer (= 1.25.0)
+  - AmazonIVSPlayer (= 1.26.0)
 
 SPEC REPOS:
   trunk:
     - AmazonIVSPlayer
 
 SPEC CHECKSUMS:
-  AmazonIVSPlayer: 716bda5a2596b08e715e7b8e014c72be4e73c27c
+  AmazonIVSPlayer: 0559d6f8004e4c9eb9a2d8fa3a10368cebd421a5
 
-PODFILE CHECKSUM: c2d765a7bce9e24a7d9b22939926ff33e502b455
+PODFILE CHECKSUM: 5c1e7464f548100959aff901547313481c912914
 
 COCOAPODS: 1.15.2


### PR DESCRIPTION
This updates the SDK dependency to the current version, 1.26.0. Gem dependencies have been updated as well.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.