### PR TITLE
Update AmazonIVSPlayer to version 1.31.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -85,7 +85,7 @@ GEM
     netrc (0.11.0)
     nkf (0.2.0)
     public_suffix (4.0.7)
-    rexml (3.2.9)
+    rexml (3.3.4)
       strscan
     ruby-macho (2.5.1)
     strscan (3.1.0)
@@ -93,13 +93,13 @@ GEM
       ethon (>= 0.9.0)
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
-    xcodeproj (1.24.0)
+    xcodeproj (1.25.0)
       CFPropertyList (>= 2.3.3, < 4.0)
       atomos (~> 0.1.3)
       claide (>= 1.0.2, < 2.0)
       colored2 (~> 3.1)
       nanaimo (~> 0.3.0)
-      rexml (~> 3.2.4)
+      rexml (>= 3.3.2, < 4.0)
 
 PLATFORMS
   arm64-darwin-21

--- a/Podfile
+++ b/Podfile
@@ -4,7 +4,7 @@ workspace 'AmazonIVSPlayerSamples'
 
 # All of the following projects consume the AmazonIVSPlayer framework as clients
 abstract_target 'IVSClients' do
-    pod 'AmazonIVSPlayer', '1.30.0'
+    pod 'AmazonIVSPlayer', '1.31.0'
 
     target 'BasicPlayback' do
         project 'BasicPlayback/BasicPlayback.xcodeproj'

--- a/Podfile.lock
+++ b/Podfile.lock
@@ -1,16 +1,16 @@
 PODS:
-  - AmazonIVSPlayer (1.30.0)
+  - AmazonIVSPlayer (1.31.0)
 
 DEPENDENCIES:
-  - AmazonIVSPlayer (= 1.30.0)
+  - AmazonIVSPlayer (= 1.31.0)
 
 SPEC REPOS:
   trunk:
     - AmazonIVSPlayer
 
 SPEC CHECKSUMS:
-  AmazonIVSPlayer: 1e0715e26c3e3468b1326cdaed75556c5a41701c
+  AmazonIVSPlayer: f8c351a8bb03e3fa05cb8ec7cc87ad2a3e6b342f
 
-PODFILE CHECKSUM: 146366e62ea03c418e52f286d09c716728a84024
+PODFILE CHECKSUM: 66918d1dbae24a6ac09aff444837e9e74abd1500
 
 COCOAPODS: 1.15.2


### PR DESCRIPTION
This updates the SDK dependency to the current version, 1.31.0. Gem dependencies have been updated as well.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.